### PR TITLE
Add Intel Quark X1000 GPIO Controller (non-legacy) support v2

### DIFF
--- a/cpu/x86/Makefile.x86_quarkX1000
+++ b/cpu/x86/Makefile.x86_quarkX1000
@@ -2,7 +2,7 @@ include $(CONTIKI)/cpu/x86/Makefile.x86_common
 
 CONTIKI_CPU_DIRS += drivers/legacy_pc drivers/quarkX1000 init/legacy_pc
 
-CONTIKI_SOURCEFILES += bootstrap_quarkX1000.S rtc.c pit.c pic.c irq.c nmi.c pci.c uart-16x50.c uart.c
+CONTIKI_SOURCEFILES += bootstrap_quarkX1000.S rtc.c pit.c pic.c irq.c nmi.c pci.c uart-16x50.c uart.c gpio.c
 
 CFLAGS += -m32 -march=i586 -mtune=i586
 LDFLAGS += -m32 -Xlinker -T -Xlinker $(CONTIKI)/cpu/x86/quarkX1000.ld

--- a/cpu/x86/drivers/legacy_pc/pci.c
+++ b/cpu/x86/drivers/legacy_pc/pci.c
@@ -234,12 +234,9 @@ pci_pirq_set_irq(PIRQ pirq, uint8_t irq, uint8_t route_to_legacy)
  * \param meta     Base address of optional driver-defined metadata.
  */
 void
-pci_init_bar0(pci_driver_t *c_this,
-              pci_config_addr_t pci_addr,
-              uintptr_t meta)
+pci_init(pci_driver_t *c_this, pci_config_addr_t pci_addr, uintptr_t meta)
 {
-  pci_addr.reg_off = PCI_CONFIG_REG_BAR0;
-  /* The BAR0 value is masked to clear non-address bits. */
+  /* The reg_off (BAR) value is masked to clear non-address bits. */
   c_this->mmio = pci_config_read(pci_addr) & ~0xFFF;
   c_this->meta = meta;
 }

--- a/cpu/x86/drivers/legacy_pc/pci.h
+++ b/cpu/x86/drivers/legacy_pc/pci.h
@@ -34,8 +34,9 @@
 #include <stdint.h>
 #include "helpers.h"
 
-/** PCI configuration register identifier for Base Address Register 0 (BAR0) */
+/** PCI configuration register identifier for Base Address Registers */
 #define PCI_CONFIG_REG_BAR0 0x10
+#define PCI_CONFIG_REG_BAR1 0x14
 
 /** PCI Interrupt Routing is mapped using Interrupt Queue Agents */
 typedef enum {
@@ -106,9 +107,7 @@ typedef struct pci_driver {
   uintptr_t meta; /**< Driver-defined metadata base address */
 } pci_driver_t;
 
-void pci_init_bar0(pci_driver_t *c_this,
-                   pci_config_addr_t pci_addr,
-                   uintptr_t meta);
+void pci_init(pci_driver_t *c_this, pci_config_addr_t pci_addr, uintptr_t meta);
 int pci_irq_agent_set_pirq(IRQAGENT agent, INTR_PIN pin, PIRQ pirq);
 void pci_pirq_set_irq(PIRQ pirq, uint8_t irq, uint8_t route_to_legacy);
 

--- a/cpu/x86/drivers/legacy_pc/uart-16x50.c
+++ b/cpu/x86/drivers/legacy_pc/uart-16x50.c
@@ -79,7 +79,7 @@ uart_16x50_init(uart_16x50_driver_t *c_this,
   /* This assumes that the UART had an MMIO range assigned to it by the
    * firmware during boot.
    */
-  pci_init_bar0(c_this, pci_addr, 0);
+  pci_init(c_this, pci_addr, 0);
 
   uart_16x50_regs_t *regs = (uart_16x50_regs_t *)c_this->mmio;
 

--- a/cpu/x86/drivers/quarkX1000/gpio.c
+++ b/cpu/x86/drivers/quarkX1000/gpio.c
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2015, Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gpio.h"
+#include "helpers.h"
+
+/* GPIO Controler Registers */
+#define SWPORTA_DR    0x00
+#define SWPORTA_DDR   0x04
+#define INTEN         0x30
+#define INTMASK       0x34
+#define INTTYPE_LEVEL 0x38
+#define INT_POLARITY  0x3c
+#define INTSTATUS     0x40
+#define RAW_INTSTATUS 0x44
+#define DEBOUNCE      0x48
+#define PORTA_EOI     0x4c
+#define EXT_PORTA     0x50
+#define LS_SYNC       0x60
+
+#define PINS 8
+
+struct gpio_internal_data {
+  pci_driver_t pci;
+};
+
+static struct gpio_internal_data data;
+
+static inline uint32_t
+read(uint32_t base_addr, uint32_t offset)
+{
+  return *(uint32_t*)(base_addr + offset);
+}
+
+static inline void
+write(uint32_t base_addr, uint32_t offset, uint32_t val)
+{
+  *(uint32_t*)(base_addr + offset) = val;
+}
+
+/* value must be 0x0 or 0x1 */
+static void
+set_bit(uint32_t base_addr, uint32_t offset, uint32_t bit, uint32_t value)
+{
+  uint32_t reg;
+
+  reg = read(base_addr, offset);
+
+  reg &= ~BIT(bit);
+  reg |= value << bit;
+
+  write(base_addr, offset, reg);
+}
+
+int
+quarkX1000_gpio_config(uint8_t pin, int flags)
+{
+  if (((flags & QUARKX1000_GPIO_IN) && (flags & QUARKX1000_GPIO_OUT)) ||
+    ((flags & QUARKX1000_GPIO_INT) && (flags & QUARKX1000_GPIO_OUT))) {
+    return -1;
+  }
+
+  /* interrupts are not supported yet */
+  if (flags & QUARKX1000_GPIO_INT)
+    return -1;
+
+  /* set direction */
+  set_bit(data.pci.mmio, SWPORTA_DDR, pin, !!(flags & QUARKX1000_GPIO_OUT));
+
+  /* set interrupt disabled */
+  set_bit(data.pci.mmio, INTEN, pin, 0);
+
+  return 0;
+}
+
+int
+quarkX1000_gpio_config_port(int flags)
+{
+  uint8_t i;
+
+  for (i = 0; i < PINS; i++) {
+    if (quarkX1000_gpio_config(i, flags) < 0) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+int
+quarkX1000_gpio_read(uint8_t pin, uint8_t *value)
+{
+  uint32_t value32 = read(data.pci.mmio, EXT_PORTA);
+  *value = !!(value32 & BIT(pin));
+
+  return 0;
+}
+
+int
+quarkX1000_gpio_write(uint8_t pin, uint8_t value)
+{
+  set_bit(data.pci.mmio, SWPORTA_DR, pin, !!value);
+  return 0;
+}
+
+int
+quarkX1000_gpio_read_port(uint8_t *value)
+{
+  uint32_t value32 = read(data.pci.mmio, EXT_PORTA);
+  *value = value32 & ~0xFFFFFF00;
+
+  return 0;
+}
+
+int
+quarkX1000_gpio_write_port(uint8_t value)
+{
+  write(data.pci.mmio, SWPORTA_DR, value);
+  return 0;
+}
+
+void
+quarkX1000_gpio_clock_enable(void)
+{
+  set_bit(data.pci.mmio, LS_SYNC, 0, 1);
+}
+
+void
+quarkX1000_gpio_clock_disable(void)
+{
+  set_bit(data.pci.mmio, LS_SYNC, 0, 0);
+}
+
+int
+quarkX1000_gpio_init(void)
+{
+  pci_config_addr_t pci_addr;
+
+  pci_addr.raw = 0;
+  pci_addr.bus = 0;
+  pci_addr.dev = 21;
+  pci_addr.func = 2;
+  pci_addr.reg_off = PCI_CONFIG_REG_BAR1;
+
+  pci_command_enable(pci_addr, PCI_CMD_1_MEM_SPACE_EN);
+
+  pci_init(&data.pci, pci_addr, 0);
+
+  quarkX1000_gpio_clock_enable();
+
+  /* clear registers */
+  write(data.pci.mmio, INTEN, 0);
+  write(data.pci.mmio, INTMASK, 0);
+  write(data.pci.mmio, PORTA_EOI, 0);
+
+  return 0;
+}

--- a/cpu/x86/drivers/quarkX1000/gpio.h
+++ b/cpu/x86/drivers/quarkX1000/gpio.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015, Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CPU_X86_DRIVERS_QUARKX1000_GPIO_H_
+#define CPU_X86_DRIVERS_QUARKX1000_GPIO_H_
+
+#include <stdint.h>
+
+#include "pci.h"
+
+#define QUARKX1000_GPIO_IN          (0 << 0)
+#define QUARKX1000_GPIO_OUT         (1 << 0)
+#define QUARKX1000_GPIO_INT         (1 << 1)
+#define QUARKX1000_GPIO_ACTIVE_LOW  (0 << 2)
+#define QUARKX1000_GPIO_ACTIVE_HIGH (1 << 2)
+#define QUARKX1000_GPIO_LEVEL       (0 << 3)
+#define QUARKX1000_GPIO_EDGE        (1 << 3)
+#define QUARKX1000_GPIO_DEBOUNCE    (1 << 4)
+#define QUARKX1000_GPIO_CLOCK_SYNC  (1 << 5)
+
+int quarkX1000_gpio_init(void);
+
+int quarkX1000_gpio_config(uint8_t pin, int flags);
+int quarkX1000_gpio_read(uint8_t pin, uint8_t *value);
+int quarkX1000_gpio_write(uint8_t pin, uint8_t value);
+
+int quarkX1000_gpio_config_port(int flags);
+int quarkX1000_gpio_read_port(uint8_t *value);
+int quarkX1000_gpio_write_port(uint8_t value);
+
+void quarkX1000_gpio_clock_enable(void);
+void quarkX1000_gpio_clock_disable(void);
+
+#endif /* CPU_X86_DRIVERS_QUARKX1000_GPIO_H_ */

--- a/cpu/x86/drivers/quarkX1000/uart.c
+++ b/cpu/x86/drivers/quarkX1000/uart.c
@@ -57,6 +57,7 @@ quarkX1000_uart_init(quarkX1000_uart_dev_t dev)
   /* PCI addresses from section 18.4 of Intel Quark SoC X1000 Datasheet. */
   pci_addr.dev = 20;
   pci_addr.func = (dev == QUARK_X1000_UART_0) ? 1 : 5;
+  pci_addr.reg_off = PCI_CONFIG_REG_BAR0;
 
   uart_16x50_init((dev == QUARK_X1000_UART_0) ? &quarkX1000_uart0 : &quarkX1000_uart1, pci_addr, QUARK_X1000_UART_DL_115200);
 }

--- a/examples/galileo/Makefile
+++ b/examples/galileo/Makefile
@@ -1,0 +1,16 @@
+KNOWN_EXAMPLES = gpio-output
+
+ifneq ($(filter $(EXAMPLE),$(KNOWN_EXAMPLES)),)
+  CONTIKI_PROJECT = $(EXAMPLE)
+else
+  CONTIKI_PROJECT = help
+endif
+
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../..
+include $(CONTIKI)/Makefile.include
+
+help:
+	@echo -e "\nSet the variable EXAMPLE to one of the following Galileo-specific examples:"
+	@for EXAMPLE in $(KNOWN_EXAMPLES); do echo $$EXAMPLE; done

--- a/examples/galileo/README
+++ b/examples/galileo/README
@@ -1,0 +1,25 @@
+Galileo Specific Examples
+=======================
+
+This directory contains galileo-specific example applications to illustrate
+how to use galileo APIs.
+
+In order to build a application, you should set the EXAMPLE environment
+variable to the name of the application you want to build. For instance, if
+you want to build gpio-output application, run the following command:
+$ make TARGET=galileo EXAMPLE=gpio-output
+
+============
+=   GPIO   =
+============
+
+GPIO Output
+===========
+
+This application shows how to use the GPIO driver APIs to manipulate output
+pins. This application sets the GPIO 4 pin as output pin and toggles its
+state at every half second.
+
+For a visual effect, you should wire shield pin IO1 to a led in a protoboard.
+Once the application is running, you should see a blinking LED.
+

--- a/examples/galileo/gpio-output.c
+++ b/examples/galileo/gpio-output.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2015, Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+
+#include "contiki.h"
+#include "sys/ctimer.h"
+
+#include "gpio.h"
+
+#define PIN 4 /* IO1 */
+
+static uint32_t value;
+static struct ctimer timer;
+
+PROCESS(gpio_output_process, "GPIO Output Process");
+AUTOSTART_PROCESSES(&gpio_output_process);
+/*---------------------------------------------------------------------------*/
+static void
+timeout(void *data)
+{
+  /* toggle pin state */
+  value = !value;
+  quarkX1000_gpio_write(PIN, value);
+
+  ctimer_reset(&timer);
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(gpio_output_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  quarkX1000_gpio_init();
+  quarkX1000_gpio_config(PIN, QUARKX1000_GPIO_OUT);
+
+  quarkX1000_gpio_clock_enable();
+
+  ctimer_set(&timer, CLOCK_SECOND / 2, timeout, NULL);
+
+  printf("GPIO output example is running\n");
+  PROCESS_YIELD();
+
+  quarkX1000_gpio_clock_disable();
+
+  PROCESS_END();
+}


### PR DESCRIPTION
Differences from v1:
    - use `pci_command_enable()` `pci_addr` parameter instead of creating a new one.
    - drop the `pci_init()` `bar` parameter and simply require the caller to properly initialize the `reg_off` field of `pci_addr`.
    - add fewer PCI command flags (only the ones specified in Intel Quark SoC X1000 datasheet.
    - fixed `offest` typo to `offset` on gpio.c
    - changed write() `offset` and `val` variable types from `uint8_t` to `uint32_t`
    - add `assert()` on `set_bit()` `value`

This patch adds files which support access to GPIO Controller
(non-legacy) configuration register through a function interface.

It doesn't add interrupt support due to pinmux reasons. On
Galileo Gen 2 we need to configure a pin as input/interrupt
using pinmux and this can only be achieved through I2C. There's
one pin exported by default as GPIO output and we used this one
to test this driver.

In the future, we plan to add an I2C driver and a pinmux configuration
driver in order to solve this kind of problems.