### PR TITLE
x86: Use -O0 instead of -Og for debug build

### DIFF
--- a/cpu/x86/Makefile.x86_common
+++ b/cpu/x86/Makefile.x86_common
@@ -18,9 +18,10 @@ ifeq ($(BUILD_RELEASE),1)
 # binary seems to be broken, check if removing this option fixes the issue.
 	LDFLAGS += -Wl,--strip-all,--gc-sections
 else
+  CFLAGS  += -O0
 	ifeq ($(findstring clang,$(CC)),clang)
-		CFLAGS  += -O0 -g
+		CFLAGS  += -g
 	else
-		CFLAGS  += -Og -ggdb3
+		CFLAGS  += -ggdb3
 	endif
 endif


### PR DESCRIPTION
This patch replaces the gcc option '-Og' by '-O0' which is used when
building debugging binaries. The motivation for this change comes
from the fact that we have found at least one optimization done by
'-Og' that interfered with one of our debugging sessions.