### PR TITLE
x86:  Reduce .eh_frame section size

### DIFF
--- a/cpu/x86/Makefile.x86_common
+++ b/cpu/x86/Makefile.x86_common
@@ -9,7 +9,7 @@ OBJCOPY  = objcopy
 SIZE     = size
 STRIP    = strip
 
-CFLAGS  += -Wall
+CFLAGS  += -Wall -fno-asynchronous-unwind-tables
 LDFLAGS += -Wl,-Map=contiki-$(TARGET).map,--build-id=none
 
 ifeq ($(BUILD_RELEASE),1)


### PR DESCRIPTION
When generating binaries, gcc will always add information of what it
calls "the exception handler framework" into its own section: .eh_frame.
This section is based on the DWARF format's call frame information (CFI) [1]
and holds information that can be useful for debuggers but also for language
constructs that relies on always having stack unwinding information (i.e. exceptions).
Such constructs, however, are pretty much useless for the C language and are
mainly just used on C++. Furthermore, this section is one of the loadable sections
of a binary, meaning it will take extra space on flash.

When .eh_frame is not present, debuggers can still get the exact same information
they need for unwinding a stack frame and for restoring registers thanks to yet
another section: .debug_frame. This section is generated by '-g' gcc option and
friends. It is actually defined by DWARF and, as opposed to .eh_frame, is not a
loadable section. In other words, it is 'strippable' while .eh_frame is not.

Since all we need is the debug information we can get from .debug_frame, we can
disable the generation of these large and unused information tables by using gcc's
'-fno-asynchronous-unwind-tables'. The .eh_frame section stays around but the code
size issue is heavily tackled. This is the same approach taken on other projects
that target small code size generation [2] [3].

Pratically speaking, on a DEBUG build of the all-timers appplication, before this
patch we had:
   text    data     bss     dec     hex filename
  21319    1188   12952   35459    8a83 all-timers.galileo

And now, after this patch:
   text    data     bss     dec     hex filename
  16347    1188   12952   30487    7717 all-timers.galileo

This means a ~5Kb reduction on the loadable text segment (.text + .rodata + .eh_frame).

The flag is applied regardless of build type, DEBUG or RELEASE, since it benefits both.
Note that when release builds apply --gc-sections, they will remove .eh_frame section entirely.

[1] http://comments.gmane.org/gmane.comp.standards.dwarf/222
[2] https://github.com/gfto/toybox/commit/0d74ad383b8bb8aa82e9cb6449b509ec6d4794a5
[3] http://git.musl-libc.org/cgit/musl/commit/?id=b439c051c7eee4eb4b93fc382f993aa6305ce530
[4] https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-Core-generic/LSB-Core-generic/ehframechpt.html

Signed-off-by: Jesus Sanchez-Palencia <jesus.sanchez-palencia@intel.com>