### PR TITLE
x86: Extend PCI driver module to support metadata and config writes

### DIFF
--- a/cpu/x86/drivers/legacy_pc/pci.c
+++ b/cpu/x86/drivers/legacy_pc/pci.c
@@ -64,6 +64,36 @@ pci_config_read(pci_config_addr_t addr)
 }
 /*---------------------------------------------------------------------------*/
 /**
+ * \brief      Write to the PCI configuration data port.
+ * \param addr Address of PCI configuration register.
+ * \param data Value to write.
+ */
+void
+pci_config_write(pci_config_addr_t addr, uint32_t data)
+{
+  set_addr(addr);
+
+  outl(PCI_CONFIG_DATA_PORT, data);
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief       Enable PCI command bits of the specified PCI configuration
+ *              register.
+ * \param addr  Address of PCI configuration register.
+ * \param flags Flags used to enable PCI command bits.
+ */
+void
+pci_command_enable(pci_config_addr_t addr, uint32_t flags)
+{
+  uint32_t data;
+
+  addr.reg_off = 0x04; /* PCI COMMAND_REGISTER */
+
+  data = pci_config_read(addr);
+  pci_config_write(addr, data | flags);
+}
+/*---------------------------------------------------------------------------*/
+/**
  * \brief       Set current PIRQ to interrupt queue agent. PCI based interrupts
  *              PIRQ[A:H] are then available for consumption by either the 8259
  *              PICs or the IO-APIC depending on configuration of the 8 PIRQx
@@ -201,12 +231,16 @@ pci_pirq_set_irq(PIRQ pirq, uint8_t irq, uint8_t route_to_legacy)
  *                 firmware.
  * \param c_this   Structure that will be initialized to represent the driver.
  * \param pci_addr PCI base address of device.
+ * \param meta     Base address of optional driver-defined metadata.
  */
 void
-pci_init_bar0(pci_driver_t *c_this, pci_config_addr_t pci_addr)
+pci_init_bar0(pci_driver_t *c_this,
+              pci_config_addr_t pci_addr,
+              uintptr_t meta)
 {
   pci_addr.reg_off = PCI_CONFIG_REG_BAR0;
   /* The BAR0 value is masked to clear non-address bits. */
   c_this->mmio = pci_config_read(pci_addr) & ~0xFFF;
+  c_this->meta = meta;
 }
 /*---------------------------------------------------------------------------*/

--- a/cpu/x86/drivers/legacy_pc/uart-16x50.c
+++ b/cpu/x86/drivers/legacy_pc/uart-16x50.c
@@ -79,7 +79,7 @@ uart_16x50_init(uart_16x50_driver_t *c_this,
   /* This assumes that the UART had an MMIO range assigned to it by the
    * firmware during boot.
    */
-  pci_init_bar0(c_this, pci_addr);
+  pci_init_bar0(c_this, pci_addr, 0);
 
   uart_16x50_regs_t *regs = (uart_16x50_regs_t *)c_this->mmio;
 


### PR DESCRIPTION
This patch adds the 'meta' field to the generic driver structure to
point to optional driver-defined metadata.  It also modifies the
associated initialization routine to populate it and updates the 16X50
UART driver to use the new initialization routine signature.  This
patch also adds a function to perform PCI configuration register
writes, definitions for the PCI Command configuration register address
and some of the bits in that register, and a function to set
additional bits in that register.  Finally, it adds macros to help
with performing MMIO to and from PCI devices.