### PR TITLE
x86: Add Intel Quark X1000 GPIO Controller (non-legacy) interrupt support

### DIFF
--- a/cpu/x86/drivers/quarkX1000/gpio.h
+++ b/cpu/x86/drivers/quarkX1000/gpio.h
@@ -54,6 +54,8 @@
 #define QUARKX1000_GPIO_POL_MASK        (1 << 6)
 #define QUARKX1000_GPIO_PUD_MASK        (3 << 7)
 
+typedef void (*quarkX1000_gpio_callback)(uint32_t);
+
 int quarkX1000_gpio_init(void);
 
 int quarkX1000_gpio_config(uint8_t pin, int flags);
@@ -63,6 +65,8 @@ int quarkX1000_gpio_write(uint8_t pin, uint8_t value);
 int quarkX1000_gpio_config_port(int flags);
 int quarkX1000_gpio_read_port(uint8_t *value);
 int quarkX1000_gpio_write_port(uint8_t value);
+
+int quarkX1000_gpio_set_callback(quarkX1000_gpio_callback callback);
 
 void quarkX1000_gpio_clock_enable(void);
 void quarkX1000_gpio_clock_disable(void);

--- a/examples/galileo/Makefile
+++ b/examples/galileo/Makefile
@@ -1,6 +1,6 @@
 TARGET=galileo
 
-KNOWN_EXAMPLES = gpio-input gpio-output i2c-LSM9DS0
+KNOWN_EXAMPLES = gpio-input gpio-output gpio-interrupt i2c-LSM9DS0
 
 ifneq ($(filter $(EXAMPLE),$(KNOWN_EXAMPLES)),)
   CONTIKI_PROJECT = $(EXAMPLE)

--- a/examples/galileo/README
+++ b/examples/galileo/README
@@ -31,6 +31,16 @@ pins. This application uses default galileo pinmux initialization and sets
 the GPIO 5 (IO2) as output pin and GPIO 6 (IO3) as input. It toggles the
 output pin state at every half second and checks the value on input pin.
 
+GPIO Interrupt
+==============
+
+This application shows how to use the GPIO driver APIs to manipulate interrupt
+pins. This application uses default galileo pinmux initialization and sets
+the GPIO 5 (IO2) as output pin and GPIO 6 (IO3) as interrupt. It toggles the
+output pin stat at every half second in order to emulate an interrupt. This
+triggers an interrupt and the application callback is called. You can confirm
+that though the UART output.
+
 =======
 = I2C =
 =======

--- a/examples/galileo/gpio-interrupt.c
+++ b/examples/galileo/gpio-interrupt.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015, Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+
+#include "contiki.h"
+#include "sys/ctimer.h"
+
+#include "gpio.h"
+#include "i2c.h"
+#include "galileo-pinmux.h"
+
+#define PIN_OUTPUT 5
+#define PIN_INTR 6
+
+static struct ctimer timer;
+static struct quarkX1000_i2c_config i2c_config;
+
+PROCESS(gpio_interrupt_process, "GPIO Interrupt Process");
+AUTOSTART_PROCESSES(&gpio_interrupt_process);
+/*---------------------------------------------------------------------------*/
+static void
+timeout(void *data)
+{
+  /* emulate an interrupt */
+  quarkX1000_gpio_write(PIN_OUTPUT, 0);
+  quarkX1000_gpio_write(PIN_OUTPUT, 1);
+
+  ctimer_reset(&timer);
+}
+/*---------------------------------------------------------------------------*/
+static void
+callback(uint32_t status)
+{
+  printf("GPIO interrupt callback called, status: %d\n", status);
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(gpio_interrupt_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  i2c_config.speed = QUARKX1000_I2C_SPEED_STANDARD;
+  i2c_config.addressing_mode = QUARKX1000_I2C_ADDR_MODE_7BIT;
+
+  quarkX1000_i2c_init();
+  quarkX1000_i2c_configure(&i2c_config);
+
+  /* use default pinmux configuration */
+  galileo_pinmux_initialize();
+
+  quarkX1000_gpio_init();
+  quarkX1000_gpio_config(PIN_OUTPUT, QUARKX1000_GPIO_OUT);
+  quarkX1000_gpio_config(PIN_INTR, QUARKX1000_GPIO_INT | QUARKX1000_GPIO_ACTIVE_HIGH | QUARKX1000_GPIO_EDGE);
+
+  quarkX1000_gpio_set_callback(callback);
+
+  quarkX1000_gpio_clock_enable();
+
+  ctimer_set(&timer, CLOCK_SECOND / 2, timeout, NULL);
+
+  printf("GPIO interrupt example is running\n");
+  PROCESS_YIELD();
+
+  quarkX1000_gpio_clock_disable();
+
+  PROCESS_END();
+}


### PR DESCRIPTION
Since Galileo pinmux is available, this patch adds interrupt support for
GPIO Controller (non-legacy).

This patch is above some pending PRs:
x86: Add Intel Quark X1000 I2C support #15
x86: Add PCAL9535A support #16
x86: Add PCA9685 support #17
x86: Add Galileo pinmux support #18 