### PR TITLE
Initialize each IDT entry to zero

### DIFF
--- a/cpu/x86/init/common/idt.c
+++ b/cpu/x86/init/common/idt.c
@@ -29,6 +29,7 @@
  */
 
 #include <stdint.h>
+#include <string.h>
 
 #include "helpers.h"
 
@@ -83,6 +84,8 @@ void
 idt_init(void)
 {
   idtr_t idtr;
+
+  memset(idt, 0, sizeof(idt));
 
   /* Initialize idtr structure */
   idtr.limit = (sizeof(intr_gate_desc_t) * NUM_DESC) - 1;


### PR DESCRIPTION
Only specific IDT entries should be marked as present.  This patch
zeroes out the entire IDT during early boot so that every IDT entry is
marked as not-present until specific IDT entries are later initialized
to be present.