### PR TITLE
x86: Add support for 32-bit build hosts and old versions of GNU Make

### DIFF
--- a/cpu/x86/uefi/build_uefi.sh
+++ b/cpu/x86/uefi/build_uefi.sh
@@ -5,10 +5,17 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # This script will always run on its own basepath, no matter where you call it from.
 pushd ${SCRIPT_DIR}
 
+if [ "$(uname -m)" = "x86_64" ]; then
+    export ARCH=X64
+fi
+
 # Download the UEFI tool and library sources:
-git clone --depth=1 https://github.com/tianocore/edk2 || exit
-# This script only supports building the tools on 64-bit hosts:
-export ARCH=X64
+if [ -e edk2 ]; then
+    make -C edk2/BaseTools/Source/C/Common clean
+    make -C edk2/BaseTools/Source/C/GenFw clean
+else
+    git clone --depth=1 https://github.com/tianocore/edk2 || exit
+fi
 # Build common sources required by the GenFw tool:
 make -C edk2/BaseTools/Source/C/Common || exit
 # Build the GenFw tool that is used to generate UEFI binaries:

--- a/platform/galileo/Makefile.customrules-galileo
+++ b/platform/galileo/Makefile.customrules-galileo
@@ -24,15 +24,16 @@ debug: $(MULTIBOOT)
 	@$(GDB) $< -ex "target remote :3333"
 
 CUSTOM_RULE_LINK=1
-define LINK_template =
-%.$(1): %.co $$(PROJECT_OBJECTFILES) $$(PROJECT_LIBRARIES) contiki-$$(TARGET).a
-	$$(TRACE_LD)
-	$$(Q)$$(LD) $$(LDFLAGS) $(2) $$(TARGET_STARTFILES) $${filter-out %.a,$$^} \
-	    $${filter %.a,$$^} $$(TARGET_LIBFILES) -o $$@
-endef
 
-$(eval $(call LINK_template,$(MULTIBOOT_SFX),$(MULTIBOOT_LDFLAGS)))
-$(eval $(call LINK_template,$(UEFI_DLL_SFX),$(UEFI_LDFLAGS)))
+%.$(MULTIBOOT_SFX): %.co $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) contiki-$(TARGET).a
+	$(TRACE_LD)
+	$(Q)$(LD) $(LDFLAGS) $(MULTIBOOT_LDFLAGS) $(TARGET_STARTFILES) ${filter-out %.a,$^} \
+	    ${filter %.a,$^} $(TARGET_LIBFILES) -o $@
+
+%.$(UEFI_DLL_SFX): %.co $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) contiki-$(TARGET).a
+	$(TRACE_LD)
+	$(Q)$(LD) $(LDFLAGS) $(UEFI_LDFLAGS) $(TARGET_STARTFILES) ${filter-out %.a,$^} \
+	    ${filter %.a,$^} $(TARGET_LIBFILES) -o $@
 
 %.$(UEFI_SFX): %.$(UEFI_DLL_SFX)
 	$(Q)$(GEN_FW) -o $@ -e UEFI_APPLICATION $^


### PR DESCRIPTION
5de1b81 adds support for building the UEFI EDK2 tools on 32-bit
hosts.
54dacd5 revises a Makefile to avoid using features that are not supported in GNU Make v.3.81.