### PR TITLE
Document build prerequisites

### DIFF
--- a/cpu/x86/Makefile.x86_quarkX1000
+++ b/cpu/x86/Makefile.x86_quarkX1000
@@ -28,10 +28,6 @@ ifeq ($(EN_UEFI),1)
 	CFLAGS += -I$(EDK2_DIR)/MdePkg/Include -I$(EDK2_DIR)/MdePkg/Include/Ia32
 else
     $(info Note: UEFI support is disabled.)
-    ifndef EN_UEFI
-        $(info To enable UEFI support, run $(CONTIKI_CPU)/uefi/build_uefi.sh prior)
-        $(info to building Contiki.)
-    else
-        $(info LTO and UEFI support are mututally-exclusive.)
-    endif
+    $(info To enable UEFI support, run $(CONTIKI_CPU)/uefi/build_uefi.sh prior)
+    $(info to building Contiki.)
 endif

--- a/platform/galileo/README.md
+++ b/platform/galileo/README.md
@@ -42,6 +42,10 @@ Standard APIs:
 Building
 --------
 
+Prerequisites on all Ubuntu Linux systems include texinfo and uuid-dev.
+Additional prerequisites on 64-bit Ubuntu Linux systems include
+gcc-multilib and g++-multilib.
+
 To build applications for this platform you should first build newlib (in
 case it wasn't already built). To build newlib you can run the following
 command:


### PR DESCRIPTION
This patchset documents build prerequisites for Ubuntu Linux and removes a spurious build-time info message.