### PR TITLE
x86: Omit frame pointer when BUILD_RELEASE=1

### DIFF
--- a/cpu/x86/Makefile.x86_common
+++ b/cpu/x86/Makefile.x86_common
@@ -23,7 +23,7 @@ CFLAGS  += -Wall -fno-asynchronous-unwind-tables -fno-unwind-tables
 LDFLAGS += -Wl,-Map=contiki-$(TARGET).map,--build-id=none
 
 ifeq ($(BUILD_RELEASE),1)
-	CFLAGS  += -Os -fno-strict-aliasing -ffunction-sections -fdata-sections
+	CFLAGS  += -Os -fno-strict-aliasing -ffunction-sections -fdata-sections -fomit-frame-pointer
 # XXX: --gc-sections can be very tricky sometimes. If somehow the release
 # binary seems to be broken, check if removing this option fixes the issue.
 	LDFLAGS += -Wl,--strip-all,--gc-sections

--- a/platform/qmsi-common/bsp/qmsi/patches/omit-frame-pointer.patch
+++ b/platform/qmsi-common/bsp/qmsi/patches/omit-frame-pointer.patch
@@ -1,0 +1,13 @@
+diff --git base.mk base.mk
+index ccc2f49..6d5817b 100644
+--- base.mk
++++ base.mk
+@@ -72,7 +72,7 @@ BUILD ?= debug
+ ifeq ($(BUILD), debug)
+ CFLAGS += -O0 -g -DDEBUG
+ else ifeq ($(BUILD), release)
+-CFLAGS += -Os -ffunction-sections -fdata-sections
++CFLAGS += -Os -ffunction-sections -fdata-sections -fomit-frame-pointer
+ LDFLAGS += -Xlinker --gc-sections
+ else
+ $(error Supported BUILD values are 'release' and 'debug')


### PR DESCRIPTION
This patch adds the '-fomit-frame-pointer' option to CFLAGS when
BUILD_RELEASE=1. This option save us some bytes per each function
since instructions to handle the base pointer are not emitted.

It also adds a patch to QMSI BSP so libqmsi.a is generated without
frame pointers.

Signed-off-by: Andre Guedes <andre.guedes@intel.com>