### PR TITLE
Quark SE devboard cleanup contiki conf

### DIFF
--- a/platform/quark-se-devboard/contiki-conf.h
+++ b/platform/quark-se-devboard/contiki-conf.h
@@ -52,43 +52,29 @@ typedef uint32_t rtimer_clock_t;
  */
 #define LEDS_CONF_ALL (3)
 
-#ifndef UIP_CONF_BUFFER_SIZE
 #define UIP_CONF_BUFFER_SIZE              1280
-#endif
 
-#ifndef NETSTACK_CONF_NETWORK
 #if NETSTACK_CONF_WITH_IPV6
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
 #else
 #define NETSTACK_CONF_NETWORK rime_driver
 #endif /* NETSTACK_CONF_WITH_IPV6 */
-#endif /* NETSTACK_CONF_NETWORK */
 
-#ifndef NETSTACK_CONF_MAC
 #define NETSTACK_CONF_MAC     csma_driver
-#endif
 
-#ifndef NETSTACK_CONF_RDC
 #define NETSTACK_CONF_RDC     nullrdc_driver
-#endif
 
 /* Configure NullRDC for when it's selected */
 #define NULLRDC_802154_AUTOACK                  1
 #define NULLRDC_802154_AUTOACK_HW               1
 
-#ifndef NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE
 #define NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE    8
-#endif
 
-#ifndef NETSTACK_CONF_FRAMER
 #define NETSTACK_CONF_FRAMER  framer_802154
-#endif /* NETSTACK_CONF_FRAMER */
 
 #define NETSTACK_CONF_RADIO   cc2520_driver
 
-#ifndef CC2520_CONF_AUTOACK
 #define CC2520_CONF_AUTOACK              1
-#endif /* CC2520_CONF_AUTOACK */
 
 #define RF_CHANNEL 26
 
@@ -102,12 +88,8 @@ typedef uint32_t rtimer_clock_t;
 #define UIP_CONF_ROUTER                 1
 
 /* configure number of neighbors and routes */
-#ifndef NBR_TABLE_CONF_MAX_NEIGHBORS
 #define NBR_TABLE_CONF_MAX_NEIGHBORS     30
-#endif /* NBR_TABLE_CONF_MAX_NEIGHBORS */
-#ifndef UIP_CONF_MAX_ROUTES
 #define UIP_CONF_MAX_ROUTES   30
-#endif /* UIP_CONF_MAX_ROUTES */
 
 #define UIP_CONF_ND6_SEND_NA    0
 #define UIP_CONF_ND6_SEND_RA    0
@@ -115,38 +97,25 @@ typedef uint32_t rtimer_clock_t;
 #define UIP_CONF_ND6_RETRANS_TIMER      10000
 
 #define NETSTACK_CONF_WITH_IPV6                   1
-#ifndef UIP_CONF_IPV6_QUEUE_PKT
 #define UIP_CONF_IPV6_QUEUE_PKT         0
-#endif /* UIP_CONF_IPV6_QUEUE_PKT */
 #define UIP_CONF_IPV6_CHECKS            1
 #define UIP_CONF_IPV6_REASSEMBLY        0
 #define UIP_CONF_NETIF_MAX_ADDRESSES    3
 #define UIP_CONF_IP_FORWARD             0
-#ifndef UIP_CONF_BUFFER_SIZE
-#define UIP_CONF_BUFFER_SIZE    240
-#endif
 
 #define SICSLOWPAN_CONF_COMPRESSION             SICSLOWPAN_COMPRESSION_HC06
-#ifndef SICSLOWPAN_CONF_FRAG
 #define SICSLOWPAN_CONF_FRAG                    1
 #define SICSLOWPAN_CONF_MAXAGE                  8
-#endif /* SICSLOWPAN_CONF_FRAG */
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS       2
-#ifndef SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS
 #define SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS   5
-#endif /* SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS */
 #else /* NETSTACK_CONF_WITH_IPV6 */
 #define UIP_CONF_IP_FORWARD      1
 #define UIP_CONF_BUFFER_SIZE     108
 #endif /* NETSTACK_CONF_WITH_IPV6 */
 
 #define UIP_CONF_LLH_LEN         0
-#ifndef  UIP_CONF_RECEIVE_WINDOW
 #define UIP_CONF_RECEIVE_WINDOW  48
-#endif
-#ifndef  UIP_CONF_TCP_MSS
 #define UIP_CONF_TCP_MSS         48
-#endif
 #define UIP_CONF_MAX_CONNECTIONS 4
 #define UIP_CONF_MAX_LISTENPORTS 8
 #define UIP_CONF_UDP_CONNS       12

--- a/platform/quark-se-devboard/contiki-conf.h
+++ b/platform/quark-se-devboard/contiki-conf.h
@@ -54,11 +54,7 @@ typedef uint32_t rtimer_clock_t;
 
 #define UIP_CONF_BUFFER_SIZE              1280
 
-#if NETSTACK_CONF_WITH_IPV6
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
-#else
-#define NETSTACK_CONF_NETWORK rime_driver
-#endif /* NETSTACK_CONF_WITH_IPV6 */
 
 #define NETSTACK_CONF_MAC     csma_driver
 
@@ -77,8 +73,6 @@ typedef uint32_t rtimer_clock_t;
 #define CC2520_CONF_AUTOACK              1
 
 #define RF_CHANNEL 26
-
-#ifdef NETSTACK_CONF_WITH_IPV6
 
 #define LINKADDR_CONF_SIZE              8
 
@@ -108,10 +102,6 @@ typedef uint32_t rtimer_clock_t;
 #define SICSLOWPAN_CONF_MAXAGE                  8
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS       2
 #define SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS   5
-#else /* NETSTACK_CONF_WITH_IPV6 */
-#define UIP_CONF_IP_FORWARD      1
-#define UIP_CONF_BUFFER_SIZE     108
-#endif /* NETSTACK_CONF_WITH_IPV6 */
 
 #define UIP_CONF_LLH_LEN         0
 #define UIP_CONF_RECEIVE_WINDOW  48

--- a/platform/quark-se-devboard/contiki-conf.h
+++ b/platform/quark-se-devboard/contiki-conf.h
@@ -52,70 +52,56 @@ typedef uint32_t rtimer_clock_t;
  */
 #define LEDS_CONF_ALL (3)
 
-#define UIP_CONF_BUFFER_SIZE              1280
-
-#define NETSTACK_CONF_NETWORK sicslowpan_driver
-
-#define NETSTACK_CONF_MAC     csma_driver
-
-#define NETSTACK_CONF_RDC     nullrdc_driver
-
-/* Configure NullRDC for when it's selected */
-#define NULLRDC_CONF_802154_AUTOACK                  1
-#define NULLRDC_CONF_802154_AUTOACK_HW               1
-
+#define NETSTACK_CONF_RADIO                     cc2520_driver
+#define NETSTACK_CONF_FRAMER                    framer_802154
+#define NETSTACK_CONF_RDC                       nullrdc_driver
+#define NETSTACK_CONF_MAC                       csma_driver
+#define NETSTACK_CONF_NETWORK                   sicslowpan_driver
+#define NETSTACK_CONF_WITH_IPV6                 1
 #define NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE    8
-
-#define NETSTACK_CONF_FRAMER  framer_802154
-
-#define NETSTACK_CONF_RADIO   cc2520_driver
-
-#define CC2520_CONF_AUTOACK              1
-
-#define RF_CHANNEL 26
-
-#define LINKADDR_CONF_SIZE              8
-
-#define UIP_CONF_LL_802154              1
-#define UIP_CONF_LLH_LEN                0
-
-#define UIP_CONF_ROUTER                 1
-
-/* configure number of neighbors and routes */
-#define NBR_TABLE_CONF_MAX_NEIGHBORS     30
-#define UIP_CONF_MAX_ROUTES   30
-
-#define UIP_CONF_ND6_SEND_NA    0
-#define UIP_CONF_ND6_SEND_RA    0
-#define UIP_CONF_ND6_REACHABLE_TIME     600000
-#define UIP_CONF_ND6_RETRANS_TIMER      10000
-
-#define NETSTACK_CONF_WITH_IPV6                   1
-#define UIP_CONF_IPV6_QUEUE_PKT         0
-#define UIP_CONF_IPV6_CHECKS            1
-#define UIP_CONF_IPV6_REASSEMBLY        0
-#define UIP_CONF_NETIF_MAX_ADDRESSES    3
-#define UIP_CONF_IP_FORWARD             0
 
 #define SICSLOWPAN_CONF_COMPRESSION             SICSLOWPAN_COMPRESSION_HC06
 #define SICSLOWPAN_CONF_FRAG                    1
 #define SICSLOWPAN_CONF_MAXAGE                  8
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS       2
 
-#define UIP_CONF_LLH_LEN         0
-#define UIP_CONF_RECEIVE_WINDOW  48
-#define UIP_CONF_TCP_MSS         48
-#define UIP_CONF_MAX_CONNECTIONS 4
-#define UIP_CONF_MAX_LISTENPORTS 8
-#define UIP_CONF_UDP_CONNS       12
-#define UIP_CONF_BROADCAST       1
-#define UIP_ARCH_IPCHKSUM        1
-#define UIP_CONF_UDP             1
-#define UIP_CONF_UDP_CHECKSUMS   1
-#define UIP_CONF_PINGADDRCONF    0
-#define UIP_CONF_LOGGING         0
+#define NBR_TABLE_CONF_MAX_NEIGHBORS            30
 
-#define UIP_CONF_TCP_SPLIT       0
+#define UIP_CONF_BUFFER_SIZE                    1280
+#define UIP_CONF_LL_802154                      1
+#define UIP_CONF_LLH_LEN                        0
+#define UIP_CONF_ROUTER                         1
+#define UIP_CONF_MAX_ROUTES                     30
+#define UIP_CONF_ND6_SEND_NA                    0
+#define UIP_CONF_ND6_SEND_RA                    0
+#define UIP_CONF_ND6_REACHABLE_TIME             600000
+#define UIP_CONF_ND6_RETRANS_TIMER              10000
+#define UIP_CONF_IPV6_QUEUE_PKT                 0
+#define UIP_CONF_IPV6_CHECKS                    1
+#define UIP_CONF_IPV6_REASSEMBLY                0
+#define UIP_CONF_NETIF_MAX_ADDRESSES            3
+#define UIP_CONF_IP_FORWARD                     0
+#define UIP_CONF_RECEIVE_WINDOW                 48
+#define UIP_CONF_TCP_MSS                        48
+#define UIP_CONF_MAX_CONNECTIONS                4
+#define UIP_CONF_MAX_LISTENPORTS                8
+#define UIP_CONF_UDP_CONNS                      12
+#define UIP_CONF_BROADCAST                      1
+#define UIP_ARCH_IPCHKSUM                       1
+#define UIP_CONF_UDP                            1
+#define UIP_CONF_UDP_CHECKSUMS                  1
+#define UIP_CONF_PINGADDRCONF                   0
+#define UIP_CONF_LOGGING                        0
+#define UIP_CONF_TCP_SPLIT                      0
+
+#define NULLRDC_CONF_802154_AUTOACK             1
+#define NULLRDC_CONF_802154_AUTOACK_HW          1
+
+#define CC2520_CONF_AUTOACK                     1
+
+#define RF_CHANNEL                              26
+
+#define LINKADDR_CONF_SIZE                      8
 
 /* Include the project config */
 /* PROJECT_CONF_H might be defined in the project Makefile */

--- a/platform/quark-se-devboard/contiki-conf.h
+++ b/platform/quark-se-devboard/contiki-conf.h
@@ -101,7 +101,6 @@ typedef uint32_t rtimer_clock_t;
 #define SICSLOWPAN_CONF_FRAG                    1
 #define SICSLOWPAN_CONF_MAXAGE                  8
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS       2
-#define SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS   5
 
 #define UIP_CONF_LLH_LEN         0
 #define UIP_CONF_RECEIVE_WINDOW  48

--- a/platform/quark-se-devboard/contiki-conf.h
+++ b/platform/quark-se-devboard/contiki-conf.h
@@ -108,7 +108,6 @@ typedef uint32_t rtimer_clock_t;
 #define UIP_CONF_MAX_CONNECTIONS 4
 #define UIP_CONF_MAX_LISTENPORTS 8
 #define UIP_CONF_UDP_CONNS       12
-#define UIP_CONF_FWCACHE_SIZE    30
 #define UIP_CONF_BROADCAST       1
 #define UIP_ARCH_IPCHKSUM        1
 #define UIP_CONF_UDP             1

--- a/platform/quark-se-devboard/contiki-conf.h
+++ b/platform/quark-se-devboard/contiki-conf.h
@@ -103,6 +103,13 @@ typedef uint32_t rtimer_clock_t;
 
 #define LINKADDR_CONF_SIZE                      8
 
+/* This macro defines the Node ID which is used to generate the
+ * link address.
+ */
+#ifndef NODE_ID
+#define NODE_ID                                 3
+#endif /* NODE_ID */
+
 /* Include the project config */
 /* PROJECT_CONF_H might be defined in the project Makefile */
 #ifdef PROJECT_CONF_H

--- a/platform/quark-se-devboard/contiki-conf.h
+++ b/platform/quark-se-devboard/contiki-conf.h
@@ -61,8 +61,8 @@ typedef uint32_t rtimer_clock_t;
 #define NETSTACK_CONF_RDC     nullrdc_driver
 
 /* Configure NullRDC for when it's selected */
-#define NULLRDC_802154_AUTOACK                  1
-#define NULLRDC_802154_AUTOACK_HW               1
+#define NULLRDC_CONF_802154_AUTOACK                  1
+#define NULLRDC_CONF_802154_AUTOACK_HW               1
 
 #define NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE    8
 

--- a/platform/quark-se-devboard/contiki-main.c
+++ b/platform/quark-se-devboard/contiki-main.c
@@ -39,9 +39,7 @@
 #include "net/mac/frame802154.h"
 #include "net/queuebuf.h"
 
-#if NETSTACK_CONF_WITH_IPV6
 #include "net/ipv6/uip-ds6.h"
-#endif /* NETSTACK_CONF_WITH_IPV6 */
 
 #ifndef NODE_ID
 #define NODE_ID        0x03
@@ -61,13 +59,8 @@ set_node_addr(void)
 
   memset(&n_addr, 0, sizeof(linkaddr_t));
 
-#if NETSTACK_CONF_WITH_IPV6
   n_addr.u8[7] = NODE_ID & 0xff;
   n_addr.u8[6] = NODE_ID >> 8;
-#else
-  n_addr.u8[0] = NODE_ID & 0xff;
-  n_addr.u8[1] = NODE_ID >> 8;
-#endif
 
   linkaddr_set_node_addr(&n_addr);
   printf("Network started with address ");
@@ -117,7 +110,6 @@ main(void)
   }
   cc2520_set_channel(RF_CHANNEL);
 
-#if NETSTACK_CONF_WITH_IPV6
   /* memcpy(&uip_lladdr.addr, ds2411_id, sizeof(uip_lladdr.addr)); */
   memcpy(&uip_lladdr.addr, linkaddr_node_addr.u8,
          UIP_LLADDR_LEN > LINKADDR_SIZE ? LINKADDR_SIZE : UIP_LLADDR_LEN);
@@ -146,7 +138,6 @@ main(void)
     }
     printf("%x%x\n", lladdr->ipaddr.u8[14], lladdr->ipaddr.u8[15]);
   }
-#endif
 
   autostart_start(autostart_processes);
 

--- a/platform/quark-se-devboard/contiki-main.c
+++ b/platform/quark-se-devboard/contiki-main.c
@@ -41,10 +41,6 @@
 
 #include "net/ipv6/uip-ds6.h"
 
-#ifndef NODE_ID
-#define NODE_ID        0x03
-#endif /* NODE_ID */
-
 SENSORS(&button_sensor, &button_sensor2);
 
 /*


### PR DESCRIPTION
This PR does several modifications to contiki-conf.h options in order to clean up this header.

I've broken this refactor in separated patches so it is easier to understand the motivation of each modification and to make it less painful in case we detect any regression.